### PR TITLE
remove `pkg_resources` dependency in __init__.py

### DIFF
--- a/seqfold/__init__.py
+++ b/seqfold/__init__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
 
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
+    __version__ = version(dist_name)
+except PackageNotFoundError:
     __version__ = "unknown"
 finally:
-    del get_distribution, DistributionNotFound
+    del version, PackageNotFoundError
 
 from .fold import fold, dg, dg_cache, fold, Struct, dot_bracket
 from .tm import tm, tm_cache, gc_cache

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-import sys
-
-from pkg_resources import VersionConflict, require
 from setuptools import setup, find_packages
 
 
@@ -9,12 +6,6 @@ with open("README.md", "r") as fh:
 
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
-
-try:
-    require("setuptools>=38.3")
-except VersionConflict:
-    print("Error: version of setuptools is too old (<38.3)!")
-    sys.exit(1)
 
 setup(
     name="seqfold",


### PR DESCRIPTION
See #22 for the error message

I replaced `pkg_resources` with `importlib.metadata` [as recommend](https://docs.python.org/3.13/library/importlib.metadata.html#distribution-versions)

I also tried to come up with a replacement for the check in `setup.py`, but it seems that the current check is not executed anyway when installing the package (at least when I tested it). Therefore, I didn't change it. However, if you want to replace `pkg_resources` there, maybe the following can be used (but this also didn't do anything when I tested to install it with `setuptools==38.2.5`).

```
from importlib.metadata import version, PackageNotFoundError
from packaging.version import Version
from setuptools import setup, find_packages


with open("README.md", "r") as fh:
    long_description = fh.read()

with open("requirements.txt") as f:
    requirements = f.read().splitlines()

try:
    v = version("setuptools")
except PackageNotFoundError:
    print("Error: setuptools is not installed!")
    sys.exit(1)
if Version(v) < Version("38.3"):
    print("Error: version of setuptools is too old (<38.3)!")
    sys.exit(1)
```

Or maybe add `setuptools>=38.3` to `install_requires`? Not sure what the best option is here.