### PR TITLE
ci: fix Actions warnings (run-on-arch v3, py3.13, windows-2025); bump dev version to 0.10.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.13"
       - name: Set version from release tag
         if: github.event_name == 'release'
         shell: bash
@@ -74,11 +74,10 @@ jobs:
           pytest
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') && matrix.platform.target != 'ppc64' }}
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.platform.target }}
-          # run-on-arch-action@v2 ships no ubuntu24.04 image; ubuntu22.04 has
-          # the aarch64 image needed to run the emulated test step.
+          # ubuntu22.04 provides the aarch64 image used to run the emulated tests.
           distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
@@ -107,7 +106,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.13"
       - name: Set version from release tag
         if: github.event_name == 'release'
         shell: bash
@@ -143,7 +142,7 @@ jobs:
           '
       - name: pytest
         if: ${{ !startsWith(matrix.platform.target, 'x86') }}
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3
         with:
           arch: ${{ matrix.platform.target }}
           distro: alpine_latest
@@ -167,7 +166,7 @@ jobs:
         # 32-bit CPython 3.13, and it's a legacy target with ~no users. Those
         # install from the sdist.
         platform:
-          - runner: windows-latest
+          - runner: windows-2025
             target: x64
             python_arch: x64
           - runner: windows-11-arm
@@ -224,7 +223,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.8"
+          python-version: "3.13"
       - name: Set version from release tag
         if: github.event_name == 'release'
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "seqfold"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "pyo3",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "seqfold"
 # Dev default only. Releases take the version from the GitHub Release tag, which
 # the CI injects here before building (see DEVELOPMENT.md). pyproject.toml reads
 # this via `dynamic = ["version"]`.
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Predict the minimum free energy structure of nucleic acids"
 license = "MIT"


### PR DESCRIPTION
Cleans up the GitHub Actions warnings/notices seen on recent runs, and bumps the dev-default version to 0.10.1. No code changes.

## Warnings fixed
| Warning | Cause | Fix |
| --- | --- | --- |
| `uraimo/run-on-arch-action@v2` — Node.js 20 deprecated | v2 runs on Node 20 (removed Sept 2026) | bump to **`@v3`** (node24, same inputs) |
| `[notice] A new release of pip is available: 21.1.1 -> 25.0.1` and `Cache entry deserialization failed` (macOS) | `actions/setup-python` pinned to **3.8**, whose framework Python ships an ancient pip | build with **3.13** — we ship abi3 wheels, so the build Python doesn't change the floor (still `cp38-abi3`) |
| `windows-latest requests are being redirected to windows-2025-vs2026` | implicit runner redirect | pin **`windows-2025`** |

## Version
- `Cargo.toml` dev-default `0.10.0 → 0.10.1` (and `Cargo.lock`). The actual release version still comes from the git tag at build time (tag-as-source-of-truth); this is just housekeeping so the in-tree default matches the next intended release.
- Includes pyo3 `0.24.1` (already merged to main via #27); verified at runtime here — the `cp38-abi3` wheel builds and `scripts/smoke_test.py` passes unchanged.

## Verification
- `cargo build --release`, YAML validates, `maturin develop` builds a `cp38-abi3` wheel, `python scripts/smoke_test.py` → all checks pass.
- CI on this PR will exercise the updated workflow across all platforms.