### PR TITLE
docs: remove the pypy3 install recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ The folding/Tm engine is written in **Rust** and exposed to Python through [PyO3
 
 ## Installation
 
-### pypy3 (recommended)
-
-```bash
-pypy3 -m ensurepip
-pypy3 -m pip install seqfold
-```
-
-For a 200bp sequence (on my laptop), [pypy3](https://doc.pypy.org/en/latest/index.html) takes 2.5 seconds versus 15 seconds for CPython.
-
 ### Conda
 
 ```bash


### PR DESCRIPTION
The `pypy3 (recommended)` install section is obsolete now that the folding engine is a native Rust extension:

- PyPy no longer offers a speed benefit — the heavy work is in the compiled extension, not Python — so the old *"2.5 seconds vs 15 seconds for CPython"* note is misleading.
- PyPy can't cleanly install the `cp38-abi3` wheel; it would fall back to building from the sdist (which needs a Rust toolchain).

Removes that block only. `conda` and `pip` install instructions are unchanged.